### PR TITLE
fix: improve dag api

### DIFF
--- a/src/runtime/src/error.rs
+++ b/src/runtime/src/error.rs
@@ -58,6 +58,9 @@ pub enum SquirtleError {
     /// Examples include impossible casts, schema inference not possible and
     /// non-unique column names.
     Plan(String),
+    /// Error returned when the DAG partition failed in Squirtle.
+    /// This error should not happen in normal usage of Squirtle.
+    DagPartition(String),
     /// Error returned during execution of the query.
     /// Examples include files not found, errors in parsing certain types.
     Execution(String),
@@ -127,6 +130,9 @@ impl Display for SquirtleError {
                 desc
             ),
             SquirtleError::Plan(ref desc) => write!(f, "Error during planning: {}", desc),
+            SquirtleError::DagPartition(ref desc) => {
+                write!(f, "Error during DAG partitioning: {}", desc)
+            }
             SquirtleError::Execution(ref desc) => write!(f, "Execution error: {}", desc),
             SquirtleError::FunctionGeneration(ref desc) => {
                 write!(f, "Function generation error: {}", desc)


### PR DESCRIPTION
*Issue #, if available:*

The current partition method is based on Arrow's physical plan's serialized JSON, which implies the dag is in reverse order --- the first Dag node is the final execution sub-plan. The scan operation is the last node (sub plan).

- [ ] Perhaps the DAG should be built backwards, with child nodes continually adding parent nodes.

*Description of changes:*

change API

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best-effort attempt to update all relevant documentation.
